### PR TITLE
fix flaky test

### DIFF
--- a/dddplus-test/src/test/java/io/github/dddplus/runtime/registry/IntegrationTest.java
+++ b/dddplus-test/src/test/java/io/github/dddplus/runtime/registry/IntegrationTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.Comparator;
 
 import static org.junit.Assert.*;
 
@@ -534,6 +535,7 @@ public class IntegrationTest {
         assertTrue(artifacts.getSteps().containsKey(Steps.Submit.Activity));
         List<DomainArtifacts.Step> submitSteps = artifacts.getSteps().get(Steps.Submit.Activity);
         assertEquals(4, submitSteps.size()); // FooStep, BarStep, BazStep, HamStep
+	submitSteps.sort(Comparator.comparing(DomainArtifacts.Step::getCode));
         assertEquals(Steps.Submit.GoodsValidationGroup, submitSteps.get(0).getTags()[0]);
 
         // extensions: IFooExt IMultiMatchExt IReviseStepsExt IDecideStepsExt IPartnerExt IPatternOnlyExt


### PR DESCRIPTION
The test `io.github.dddplus.runtime.registry.IntegrationTest#exportDomainArtifacts` makes assertion on the first element of a list (`assertEquals(Steps.Submit.GoodsValidationGroup, submitSteps.get(0).getTags()[0]);`), assuming the element order in the list is deterministic. However, this list is not created by the user's code, instead, it is prepared by the spring framework using reflection APIs before the actual test starts. The nondeterminism of the reflection APIs can actually lead to the different order of the elements in the list.

Therefore, to make the test pass deterministically, this PR sorts the list deterministically before the assertion.